### PR TITLE
rm ctx from geometry args in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const ctx = Context()
 const material = FlatMaterial(ctx)
 const camera = PerspectiveCamera(ctx, {position: [0, 0, 2]})
 const frame = Frame(ctx)
-const box = Mesh(ctx, { geometry: BoxGeometry(ctx) })
+const box = Mesh(ctx, { geometry: BoxGeometry() })
 
 const rotation = [0, 0, 0, 1]
 const angle = [0, 0, 0, 1]

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -53,7 +53,7 @@ const ctx = Context()
 const material = FlatMaterial(ctx)
 const camera = PerspectiveCamera(ctx, {position: [0, 0, 2]})
 const frame = Frame(ctx)
-const box = Mesh(ctx, { geometry: BoxGeometry(ctx) })
+const box = Mesh(ctx, { geometry: BoxGeometry() })
 
 const rotation = [0, 0, 0, 1]
 const angle = [0, 0, 0, 1]

--- a/doc/hello-world.md
+++ b/doc/hello-world.md
@@ -24,7 +24,7 @@ const ctx = Context()
 const material = FlatMaterial(ctx)
 const camera = PerspectiveCamera(ctx, {position: [0, 0, 2]})
 const frame = Frame(ctx)
-const box = Mesh(ctx, { geometry: BoxGeometry(ctx) })
+const box = Mesh(ctx, { geometry: BoxGeometry() })
 
 const rotation = [0, 0, 0, 1]
 const angle = [0, 0, 0, 1]

--- a/example/360-photo/index.js
+++ b/example/360-photo/index.js
@@ -30,7 +30,7 @@ const ctx = Context({
 
 // scene
 const camera = PerspectiveCamera(ctx)
-const sphere = Mesh(ctx, { geometry: SphereGeometry(ctx)})
+const sphere = Mesh(ctx, { geometry: SphereGeometry()})
 const frame = Frame(ctx)
 
 // surface

--- a/example/360-video/index.js
+++ b/example/360-video/index.js
@@ -27,7 +27,7 @@ const texture = Texture(ctx)
 const material = FlatMaterial(ctx, {map: texture})
 
 const camera = PerspectiveCamera(ctx, {position: [0, 0, 0]})
-const sphere = Mesh(ctx, { geometry: SphereGeometry(ctx)})
+const sphere = Mesh(ctx, { geometry: SphereGeometry()})
 const frame = Frame(ctx)
 
 // inputs

--- a/example/video/index.js
+++ b/example/video/index.js
@@ -17,7 +17,7 @@ import quat from 'gl-quat'
 // fullscreen canvas
 const ctx = Context()
 
-const box = Mesh(ctx, { geometry: BoxGeometry(ctx) })
+const box = Mesh(ctx, { geometry: BoxGeometry() })
 const video = document.createElement('video')
 const frame = Frame(ctx)
 const camera = OrthographicCamera(ctx, {viewport: [-1, -1, 1, 1]})


### PR DESCRIPTION
remove passing in context to geometry functions as it throws errors (which is good that it throws errors but its also why it doesn't need to be passed in as an arg).