### PR TITLE
fix linguist and ignore esdocs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+esdoc/* linguist-documentation


### PR DESCRIPTION
this should remove `esdoc` directory from github's linguist.  
no more orange html in the linguist color bar.