### PR TITLE
change how light Uniforms are handled

### DIFF
--- a/src/glsl/light/LightContext.glsl
+++ b/src/glsl/light/LightContext.glsl
@@ -1,17 +1,11 @@
 /**
- * Module dependencies.
- */
-
-#pragma glslify: DirectionalLight = require('./DirectionalLight')
-#pragma glslify: AmbientLight = require('./AmbientLight')
-#pragma glslify: PointLight = require('./PointLight')
-
-/**
  * Module exports.
  */
 
 #pragma glslify: export(DirectionalLightsContext)
 #pragma glslify: export(AmbientLightsContext)
+#pragma glslify: export(PointLightsContext)
+
 #pragma glslify: export(LightContext)
 
 // @TODO(werle) inject these defines at runtime
@@ -44,36 +38,27 @@
 //};
 
 /**
- * The DirectionalLightsContext structure encapsulates all known
- * DirectionalLights for a shader program. The total count and pointers
- * toall DirectionalLights are in this structure.
+ * The total count of all DirectionalLights are in this structure.
  */
 
 struct DirectionalLightsContext {
   int count;
-  DirectionalLight lights[MAX_DIRECTIONAL_LIGHTS];
 };
 
 /**
- * The AmbientLightsContext structure encapsulates all known
- * AmbientLights for a shader program. The total count and pointers
- * toall AmbientLights are in this structure.
+ * The total count of all AmbientLights are in this structure.
  */
 
 struct AmbientLightsContext {
   int count;
-  AmbientLight lights[MAX_AMBIENT_LIGHTS];
 };
 
 /**
- * The PointLightsContext structure encapsulates all known
- * PointLights for a shader program. The total count and pointers
- * toall PointLights are in this structure.
+ * The total count of all PointLights are in this structure.
  */
 
 struct PointLightsContext {
   int count;
-  PointLight lights[MAX_POINT_LIGHTS];
 };
 
 /**

--- a/src/glsl/material/fragments/lambert.glsl
+++ b/src/glsl/material/fragments/lambert.glsl
@@ -83,7 +83,7 @@ void main() {
 
   // accumulate ambient
   for (int i = 0; i < MAX_AMBIENT_LIGHTS; ++i) {
-    AmbientLight light = lightContext.ambient.lights[i];
+    AmbientLight light = ambientLights[i];
     if (i >= lightContext.ambient.count) {
       break;
     } else if (light.visible) {
@@ -96,7 +96,7 @@ void main() {
   }
 
   for (int i = 0; i < MAX_DIRECTIONAL_LIGHTS; ++i) {
-    DirectionalLight light = lightContext.directional.lights[i];
+    DirectionalLight light = directionalLights[i];
     if (i >= lightContext.directional.count) {
       break;
     } else if (light.visible) {
@@ -108,7 +108,7 @@ void main() {
   }
 
   for (int i = 0; i < MAX_POINT_LIGHTS; ++i) {
-    PointLight light = lightContext.point.lights[i];
+    PointLight light = pointLights[i];
     if (i >= lightContext.point.count) {
       break;
     } else if (light.visible) {

--- a/src/glsl/material/fragments/main.glsl
+++ b/src/glsl/material/fragments/main.glsl
@@ -15,6 +15,11 @@ precision mediump float;
 #pragma glslify: FlatMaterial = require('../FlatMaterial')
 #pragma glslify: Material = require('../Material')
 
+// lights
+#pragma glslify: DirectionalLight = require('../../light/DirectionalLight')
+#pragma glslify: AmbientLight = require('../../light/AmbientLight')
+#pragma glslify: PointLight = require('../../light/PointLight')
+
 
 #ifndef MAX_AMBIENT_LIGHTS
 #define MAX_AMBIENT_LIGHTS 16
@@ -52,8 +57,11 @@ varying vec3 vLocalNormal;
 // Shader uniforms.
 //
 uniform MATERIAL_TYPE material;
-uniform LightContext lightContext;
 uniform Camera camera;
+uniform LightContext lightContext;
+uniform DirectionalLight directionalLights[MAX_DIRECTIONAL_LIGHTS];
+uniform AmbientLight ambientLights[MAX_AMBIENT_LIGHTS];
+uniform PointLight pointLights[MAX_POINT_LIGHTS];
 
 #ifdef HAS_MAP
 uniform Map map;
@@ -67,7 +75,6 @@ uniform Map envmap;
 uniform Cubemap envcubemap;
 #endif
 
-
 //
 // Lambertian shading model.
 //
@@ -76,7 +83,10 @@ import drawLambertMaterial from './lambert' where {
   MAX_AMBIENT_LIGHTS=MAX_AMBIENT_LIGHTS,
   MAX_POINT_LIGHTS=MAX_POINT_LIGHTS,
   getGeometryContext=getGeometryContext,
+  directionalLights=directionalLights,
+  ambientLights=ambientLights,
   lightContext=lightContext,
+  pointLights=pointLights,
   material=material,
   envcubemap=envcubemap,
   cubemap=cubemap,
@@ -95,7 +105,10 @@ import drawPhongMaterial from './phong' where {
   MAX_AMBIENT_LIGHTS=MAX_AMBIENT_LIGHTS,
   MAX_POINT_LIGHTS=MAX_POINT_LIGHTS,
   getGeometryContext=getGeometryContext,
+  directionalLights=directionalLights,
+  ambientLights=ambientLights,
   lightContext=lightContext,
+  pointLights=pointLights,
   material=material,
   envcubemap=envcubemap,
   cubemap=cubemap,

--- a/src/glsl/material/fragments/phong.glsl
+++ b/src/glsl/material/fragments/phong.glsl
@@ -96,7 +96,7 @@ void main() {
 
   // accumulate ambient
   for (int i = 0; i < MAX_AMBIENT_LIGHTS; ++i) {
-    AmbientLight light = lightContext.ambient.lights[i];
+    AmbientLight light = ambientLights[i];
     if (i >= lightContext.ambient.count) {
       break;
     } else if (light.visible) {
@@ -109,7 +109,7 @@ void main() {
   }
 
   for (int i = 0; i < MAX_DIRECTIONAL_LIGHTS; ++i) {
-    DirectionalLight light = lightContext.directional.lights[i];
+    DirectionalLight light = directionalLights[i];
     if (i >= lightContext.directional.count) {
       break;
     } else if (light.visible) {
@@ -121,7 +121,7 @@ void main() {
   }
 
   for (int i = 0; i < MAX_POINT_LIGHTS; ++i) {
-    PointLight light = lightContext.point.lights[i];
+    PointLight light = pointLights[i];
     if (i >= lightContext.point.count) {
       break;
     } else if (light.visible) {

--- a/src/material/lambert.js
+++ b/src/material/lambert.js
@@ -277,7 +277,7 @@ export class LambertMaterialUniforms extends MaterialUniforms {
 
   setLightsInContext({identifier, type, max, defaults}) {
     for (let i = 0; i < max; ++i) {
-      const key = `lightContext.${identifier}.lights[${i}]`
+      const key = `${identifier}Lights[${i}]`
       const set = (property, fallback) => {
         Object.assign(this, {
           [`${key}.${property}`]({lights}, args = {}) {


### PR DESCRIPTION
because Safari can't handle arrays of structs nested in a struct.

recreated issue:
http://requirebin.com/?gist=f506ae52da7c014a61024515b0641cb2

likely sourcecode suspect:
https://github.com/WebKit/webkit/blob/master/Source/WebCore/platform/graphics/opengl/GraphicsContext3DOpenGLCommon.cpp#L932

no word on webkit ever planning to change this.