### PR TITLE
Inject defines in viable shader

### DIFF
--- a/src/mesh/shader/defines.js
+++ b/src/mesh/shader/defines.js
@@ -10,17 +10,17 @@ export class MeshShaderDefines extends Component {
     super(ctx, initialState,
       new ShaderDefines(ctx, {
         GLSL_MESH_HAS_POSITION({geometry}) {
-          if (geometry.positions) { return true }
+          if (geometry && geometry.positions) { return true }
           return null
         },
 
         GLSL_MESH_HAS_NORMAL({geometry}) {
-          if (geometry.normals) { return true }
+          if (geometry && geometry.normals) { return true }
           return null
         },
 
         GLSL_MESH_HAS_UV({geometry}) {
-          if (geometry.uvs) { return true }
+          if (geometry && geometry.uvs) { return true }
           return null
         }
       })

--- a/src/shader/defines.js
+++ b/src/shader/defines.js
@@ -2,15 +2,16 @@ import { ScopedContext } from '../scope'
 import { Component } from '../core'
 
 export class ShaderDefines extends Component {
-  constructor(ctx, initialState, props, ...children) {
-    if ('function' == typeof props) { children.unshift(props) }
-    if ('function' == typeof initialState) { children.unshift(initialState) }
+  constructor(ctx, initialState, props) {
     if ('object' != typeof initialState) { initialState = {} }
-    if ('object' != typeof props) { props = initialState }
+    if ('object' != typeof props) {
+      props = initialState
+      initialState = {}
+    }
     super(ctx, initialState,
       new ScopedContext(ctx, initialState, {
         defines(...args) {
-          const defines = {}
+          const {defines = {}} = args[0] // from regl context
           for (const prop in props) {
             const value = props[prop]
             if ('function' == typeof value) {


### PR DESCRIPTION
Inject defines from a viable shader allows a potential cache bust to occur when defines have changes, but the shader source has not.
